### PR TITLE
Fixed `ng lint` warnings

### DIFF
--- a/src/app/api.service.ts
+++ b/src/app/api.service.ts
@@ -6,7 +6,7 @@ import { catchError, tap, map } from 'rxjs/operators';
 const httpOptions = {
   headers: new HttpHeaders({'Content-Type': 'application/json'})
 };
-const apiUrl = "/api";
+const apiUrl = '/api';
 
 @Injectable({
   providedIn: 'root'
@@ -28,10 +28,10 @@ export class ApiService {
     }
     // return an observable with a user-facing error message
     return throwError('Something bad happened; please try again later.');
-  };
+  }
 
   private extractData(res: Response) {
-    let body = res;
+    const body = res;
     return body || { };
   }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,7 +20,7 @@ import {
   MatIconModule,
   MatButtonModule,
   MatCardModule,
-  MatFormFieldModule } from "@angular/material";
+  MatFormFieldModule } from '@angular/material';
 
 const appRoutes: Routes = [
   {

--- a/src/app/book-create/book-create.component.ts
+++ b/src/app/book-create/book-create.component.ts
@@ -11,12 +11,12 @@ import { FormControl, FormGroupDirective, FormBuilder, FormGroup, NgForm, Valida
 export class BookCreateComponent implements OnInit {
 
   bookForm: FormGroup;
-  isbn:string='';
-  title:string='';
-  description:string='';
-  author:string='';
-  publisher:string='';
-  published_year:string='';
+  isbn = '';
+  title = '';
+  description = '';
+  author = '';
+  publisher = '';
+  published_year = '';
 
   constructor(private router: Router, private api: ApiService, private formBuilder: FormBuilder) { }
 
@@ -31,10 +31,10 @@ export class BookCreateComponent implements OnInit {
     });
   }
 
-  onFormSubmit(form:NgForm) {
+  onFormSubmit(form: NgForm) {
     this.api.postBook(form)
       .subscribe(res => {
-          let id = res['_id'];
+          const id = res['_id'];
           this.router.navigate(['/book-details', id]);
         }, (err) => {
           console.log(err);

--- a/src/app/book-edit/book-edit.component.ts
+++ b/src/app/book-edit/book-edit.component.ts
@@ -11,13 +11,13 @@ import { FormControl, FormGroupDirective, FormBuilder, FormGroup, NgForm, Valida
 export class BookEditComponent implements OnInit {
 
   bookForm: FormGroup;
-  id:string = '';
-  isbn:string = '';
-  title:string = '';
-  description:string = '';
-  author:string = '';
-  publisher:string = '';
-  published_year:string = '';
+  id = '';
+  isbn = '';
+  title = '';
+  description = '';
+  author = '';
+  publisher = '';
+  published_year = '';
 
   constructor(private router: Router, private route: ActivatedRoute, private api: ApiService, private formBuilder: FormBuilder) { }
 
@@ -47,10 +47,10 @@ export class BookEditComponent implements OnInit {
     });
   }
 
-  onFormSubmit(form:NgForm) {
+  onFormSubmit(form: NgForm) {
     this.api.updateBook(this.id, form)
       .subscribe(res => {
-          let id = res['_id'];
+          const id = res['_id'];
           this.router.navigate(['/book-details', id]);
         }, (err) => {
           console.log(err);

--- a/src/app/book/book.component.ts
+++ b/src/app/book/book.component.ts
@@ -3,6 +3,20 @@ import { ApiService } from '../api.service';
 import { DataSource } from '@angular/cdk/collections';
 import { Observable } from 'rxjs';
 
+export class BookDataSource extends DataSource<any> {
+  constructor(private api: ApiService) {
+    super();
+  }
+
+  connect() {
+    return this.api.getBooks();
+  }
+
+  disconnect() {
+
+  }
+}
+
 @Component({
   selector: 'app-book',
   templateUrl: './book.component.html',
@@ -24,19 +38,5 @@ export class BookComponent implements OnInit {
       }, err => {
         console.log(err);
       });
-  }
-}
-
-export class BookDataSource extends DataSource<any> {
-  constructor(private api: ApiService) {
-    super()
-  }
-
-  connect() {
-    return this.api.getBooks();
-  }
-
-  disconnect() {
-
   }
 }


### PR DESCRIPTION
- double quote vs. single quote,
- BookDataSource used before declaration,
- missed semicolon
- unnececary semicolon
- missed whitespace
- let vs. const

I spotted on lint errors, when I worked with code example step by step.
Then I checked this repo, I realized the code originally not checked with `ng lint`.
So here I am - with small code changes, so that code syntax is correct now.

@didinj please consider this to merge, BUT, make sure u test/verify it.
And if os, also, please update ur article content on page:
https://www.djamware.com/post/5b00bb9180aca726dee1fd6d/mean-stack-angular-6-crud-web-application

Related to issue #3 